### PR TITLE
Carousel Generic - Modifications

### DIFF
--- a/models/Carousel.js
+++ b/models/Carousel.js
@@ -1,0 +1,21 @@
+/**
+ * Created by matjames007 on 2/10/16.
+ */
+var keystone = require('keystone');
+
+/**
+ * Carousel Model
+ * ==================
+ */
+
+var Carousel = new keystone.List('Carousel', {
+    autokey: { from: 'name', path: 'key', unique: true }
+});
+
+Carousel.add({
+    name: { type: String, required: true }
+});
+
+Carousel.relationship({ ref: 'Slide', path: 'carousel' });
+
+Carousel.register();

--- a/models/Slide.js
+++ b/models/Slide.js
@@ -1,0 +1,30 @@
+/**
+ * Created by matjames007 on 2/10/16.
+ */
+/**
+ * Created by tremaine on 1/28/16.
+ */
+(function(){
+
+    var keystone = require('keystone');
+    var Types = keystone.Field.Types;
+
+    /**
+     * Slide Model
+     * ==========
+     */
+
+    var Slide = new keystone.List('Slide');
+
+    Slide.add({
+        title: { type: String, required: true, default: 'title' },
+        subText: { type: String},
+        image: { type: Types.CloudinaryImage },
+        link: { type: String},
+        carousel: { type: Types.Relationship, ref: 'Carousel', many: true }
+    });
+
+
+    Slide.defaultColumns = 'carousel, title, link';
+    Slide.register();
+})();

--- a/public/app/modules/home/home.controller.js
+++ b/public/app/modules/home/home.controller.js
@@ -60,10 +60,10 @@
                         .query({id: carousel._id}, function(slides) {
                             $scope.slides = slides;
                         }, function(error) {
-
+                            $scope.slides = {};
                         })
                 }, function(error) {
-                    //TODO: Need to tie up these lose ends
+                    $scope.slides = {};
                 });
 
             /**

--- a/public/app/modules/home/home.controller.js
+++ b/public/app/modules/home/home.controller.js
@@ -50,16 +50,22 @@
             }, function(error){
                     $scope.page_content = {};
                 });
+
             /**
-             * Retrieve all resources (pages and posts) which are flagged
-             * for display within the carousel.
+             * Retrieve the carousel based on name
              */
-            dataService.getCarouselItems()
-                .query({carousel: 'yes', sortResultBy: 'positionInCarousel'}, function(carousel_items){
-                $scope.slides = carousel_items;
-            }, function(error){
-                $scope.slides = {};
-            });
+            dataService.getCarousel()
+                .show({name:'HomePage'}, function(carousel) {
+                    dataService.getSlides()
+                        .query({id: carousel._id}, function(slides) {
+                            $scope.slides = slides;
+                        }, function(error) {
+
+                        })
+                }, function(error) {
+                    //TODO: Need to tie up these lose ends
+                });
+
             /**
              * Retrieve all published news items.
              */

--- a/public/app/modules/home/home.html
+++ b/public/app/modules/home/home.html
@@ -6,7 +6,7 @@
 		<header id="header-carousel" class="carousel slide">
 			<uib-carousel interval="interval" no-wrap="noWrapSlides">
 				<uib-slide ng-repeat="slide in slides">
-					<a href="#/{{slide.link}}">
+					<a href="{{slide.link}}">
 						<div id="hero" class="col-sm-12 col-md-12 col-lg-12 no-padding" style="background-image: url({{slide.image.secure_url}});">
 							<div class="box-caption">
 								<!--------------------Hero-------------------->
@@ -19,7 +19,7 @@
 	                                        {{slide.title}}
 	                                    </span>
 	                                    <span class="sub-title-1 white-text">
-											{{slide.subTitle}}
+											{{slide.subText}}
 	                                    </span>
 									</div>
 								</div>

--- a/public/app/modules/partials/navbar.html
+++ b/public/app/modules/partials/navbar.html
@@ -31,7 +31,7 @@
 							<!--<li><a href="#/our-process">Our Process</a></li>-->
 						<!--</ul>-->
 					<!--</li>-->
-					<li><a class="dark-grey-text" href="#/who-we-are">About</a></li>
+					<li><a class="dark-grey-text" href="/who-we-are">About</a></li>
 					<!--<li class="dropdown" uib-dropdown>-->
 						<!--<a class="dropdown-toggle dark-grey-text" uib-dropdown-toggle>-->
 							<!--About-->

--- a/public/app/modules/shared_services/data.service.js
+++ b/public/app/modules/shared_services/data.service.js
@@ -37,7 +37,9 @@
             getCarouselItems: getCarouselItems,
             getNewsItems: getNewsItems,
             getHomePageContent: getHomePageContent,
-            getPage: getPage
+            getPage: getPage,
+            getCarousel: getCarousel,
+            getSlides: getSlides
         };
 
         return service;
@@ -60,13 +62,21 @@
             });
         }
         /**
-         * Retrieves all pages and posts flagged for
-         * display within the carousel.
+         * Retrieves carousel based on name.
          * @returns {*}
          */
-        function getCarouselItems(){
-            return $resource(ROUTES.baseUrl + 'search',{},{
-                query: {method: 'GET', isArray: true}
+        function getCarousel(){
+            return $resource(ROUTES.baseUrl + 'carousel/:name',{},{
+                show: {method: 'GET', params: {name: '@name'} }
+            });
+        }
+        /**
+         * Retrieves all slides based on carousel id.
+         * @returns {*}
+         */
+        function getSlides(){
+            return $resource(ROUTES.baseUrl + ':id/slides',{},{
+                query: {method: 'GET', params: {id: '@id'}, isArray: true}
             });
         }
         /**

--- a/public/app/modules/shared_services/data.service.js
+++ b/public/app/modules/shared_services/data.service.js
@@ -34,7 +34,6 @@
         var service = {
             getPosts : getPosts,
             getPost: getPost,
-            getCarouselItems: getCarouselItems,
             getNewsItems: getNewsItems,
             getHomePageContent: getHomePageContent,
             getPage: getPage,

--- a/routes/api/carousel.js
+++ b/routes/api/carousel.js
@@ -1,0 +1,65 @@
+/**
+ * Created by matjames007 on 2/10/16.
+ */
+(function(){
+    var keystone = require('keystone'),
+        Slide = keystone.list('Slide'),
+        Carousel = keystone.list('Carousel'),
+        utils = require('../../util/utils'),
+        _ = require('underscore');
+    /**
+     * Searches slides by query parameters.
+     * @param req
+     * @param res
+     */
+    exports.index = function(req, res){
+        var query = {};
+        //Build a query based on query parameters list.
+        //If no query parameters are present,
+        //return all posts from the database.
+        if(!_.isEmpty(req.query)){
+            query = utils.buildQuery(req.query);
+        }
+        Slide.model
+            .find(query)
+            .populate('carousel')
+            .exec(function(err, slides){
+                if(err || !slides){
+                    utils.handleDBError(err, res)
+                }else{
+                    res.json(slides);
+                }
+            });
+    };
+
+    exports.byCarouselId = function(req, res) {
+        Slide.model.find()
+            .populate('carousel')
+            .exec(function(err, slides) {
+                if(err || !slides){
+                    utils.handleDBError(err, res)
+                }else{
+                    var list = [];
+                    for(s in slides) {
+                        for(c in slides[s].carousel) {
+                            if(slides[s].carousel[c]._id == req.params.c_id) {
+                                list.push(slides[s]);
+                                break;
+                            }
+                        }
+                    }
+                    res.json(list);
+                }
+            });
+    };
+
+    exports.getCarouselByName = function(req, res) {
+        Carousel.model.findOne({name: req.params.name}, function(err, item) {
+            if(err || !item){
+                utils.handleDBError(err, res)
+            }else{
+                res.json(item);
+            }
+        });
+    }
+})();

--- a/routes/index.js
+++ b/routes/index.js
@@ -18,6 +18,9 @@ exports = module.exports = function(app) {
 	app.get('/', routes.views.index);
 	//Custom api endpoints created for consumption by the front end.
 	app.get('/api/posts', keystone.middleware.api, routes.api.post.index);
+	app.get('/api/slides', keystone.middleware.api, routes.api.carousel.index);
+	app.get('/api/:c_id/slides', keystone.middleware.api, routes.api.carousel.byCarouselId);
+	app.get('/api/carousel/:name', keystone.middleware.api, routes.api.carousel.getCarouselByName);
 	app.get('/api/search', keystone.middleware.api, routes.api.search.index);
 	app.get('/api/news', keystone.middleware.api, routes.api.news.index);
 	app.get('/api/posts/:slug', keystone.middleware.api, routes.api.post.show);


### PR DESCRIPTION
The idea here is for a carousel that is agnostic to content and can have multiple instances running on the same site.  This was achieved by having a grouping as follows:
A `slide` can be referenced by one or more `carousels`.  A `slide` simply becomes an object with a title, text, image and a url.

In order to get the carousel for the home page we do:

```
GET api/carousel/<name> or GET api/carousel/HomePage
```

this will return an object with an `_id`.  This `_id` can be used to retrieve the slides that are to be included for the referenced carousel by doing:

```
GET api/<id>/slides or GET api/342423223423ef2313ae/slides
```
