### PR TITLE
Sorting by Position

### DIFF
--- a/models/Slide.js
+++ b/models/Slide.js
@@ -21,10 +21,11 @@
         subText: { type: String},
         image: { type: Types.CloudinaryImage },
         link: { type: String},
+		position: {type: Number},
         carousel: { type: Types.Relationship, ref: 'Carousel', many: true }
     });
 
 
-    Slide.defaultColumns = 'carousel, title, link';
+    Slide.defaultColumns = 'carousel, title, link, position';
     Slide.register();
 })();

--- a/routes/api/carousel.js
+++ b/routes/api/carousel.js
@@ -35,6 +35,7 @@
     exports.byCarouselId = function(req, res) {
         Slide.model.find()
             .populate('carousel')
+			.sort('position')
             .exec(function(err, slides) {
                 if(err || !slides){
                     utils.handleDBError(err, res)


### PR DESCRIPTION
As described in Issue #70 - it was not possible to set a position of an item in the carousel.  This has been changed with a simple number order.  In a set of slides with positions `[2,3,0]` - the slide with position `0` will appear first.
